### PR TITLE
Adding server time to item list response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,14 @@ out/
 .idea/libraries/Maven__com_fasterxml_jackson_datatype_jackson_datatype_jsr310_2_5_1.xml
 .idea/vcs.xml
 
+# eclipse generated files
+RemoteSystemsTempFiles/
+.metadata
+.classpath
+.project
+.settings
+/bin/
 
 target.zip
 Target/
+/target/

--- a/src/main/java/com/impinj/itemsense/client/data/item/ItemController.java
+++ b/src/main/java/com/impinj/itemsense/client/data/item/ItemController.java
@@ -4,9 +4,12 @@ import com.google.gson.Gson;
 import com.impinj.itemsense.client.helpers.RestApiHelper;
 import com.impinj.itemsense.client.data.EpcFormat;
 import com.impinj.itemsense.client.data.PresenceConfidence;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
 import java.util.*;
 
 /**
@@ -15,12 +18,12 @@ import java.util.*;
 public class ItemController {
     private Gson gson;
     private WebTarget target;
-    private RestApiHelper<ItemResponse> restApiHelper;
+    private RestApiHelper<Response> restApiHelper;
 
     public ItemController(final Gson gson, WebTarget target) {
         this.gson = gson;
         this.target = target;
-        this.restApiHelper = new RestApiHelper<ItemResponse>(ItemResponse.class);
+    	this.restApiHelper = new RestApiHelper<>(Response.class);
     }
 
     public ItemResponse getItems(EpcFormat epcFormat, String epcPrefix, String zoneNames, PresenceConfidence presenceConfidence, String facility,
@@ -52,8 +55,15 @@ public class ItemController {
 
     }
 
-    public ItemResponse getItems(HashMap<String, Object> queryParams) {
-        return this.restApiHelper.get(queryParams, "/data/v1/items/show", target, gson);
+    public ItemResponse getItems(final HashMap<String, Object> queryParams) {
+		final Response response = this.restApiHelper.get(queryParams, "/data/v1/items/show", target, gson);
+		final ItemResponse itemResponse = response.readEntity(ItemResponse.class);
+		if (response.getHeaderString("date") != null)
+		{
+			final ZonedDateTime time = ZonedDateTime.parse(response.getHeaderString("date"), DateTimeFormatter.RFC_1123_DATE_TIME);
+			itemResponse.setTime(time);
+		}
+		return itemResponse;
     }
 
     public ItemResponse getItems() {

--- a/src/main/java/com/impinj/itemsense/client/data/item/ItemResponse.java
+++ b/src/main/java/com/impinj/itemsense/client/data/item/ItemResponse.java
@@ -1,10 +1,12 @@
 package com.impinj.itemsense.client.data.item;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.ZonedDateTime;
 /**
  * Created by jcombopi on 1/26/16.
  */
@@ -19,5 +21,8 @@ public class ItemResponse {
 
     @JsonProperty("nextPageMarker")
     private String nextPageMarker;
+    
+    @JsonIgnore
+    private ZonedDateTime time;
 }
 

--- a/src/main/java/com/impinj/itemsense/client/helpers/ZonedDateTimeSerialization.java
+++ b/src/main/java/com/impinj/itemsense/client/helpers/ZonedDateTimeSerialization.java
@@ -20,7 +20,6 @@ public class ZonedDateTimeSerialization extends JsonDeserializer<ZonedDateTime> 
 
     @Override
     public ZonedDateTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
-        System.out.println("ZonedDateTimeSerialization::deserialize()");
         return ZonedDateTime.parse(jsonParser.getText());
     }
 

--- a/src/test/java/com.impinj.itemsense.client/data/ItemControllerTest.java
+++ b/src/test/java/com.impinj.itemsense.client/data/ItemControllerTest.java
@@ -47,7 +47,7 @@ public class ItemControllerTest {
         itemController = dataApiController.getItemController();
         gson = new GsonBuilder().registerTypeAdapter(ZonedDateTime.class, new ZonedDateTimeSerialization()).create();
         Item item = gson.fromJson("{\"epc\":\"30140008782B0AC000000001\",\"tagId\":\"000000000000\",\"xLocation\":-0.4,\"yLocation\":-0.3,\"zLocation\":0,\"zone\":\"Bryan_Office\",\"facility\":null,\"presenceConfidence\":\"HIGH\",\"lastModifiedTime\":\"2016-02-01T19:53:39Z\"}", Item.class);
-        itemResponseTest = new ItemResponse(new Item[]{item}, null);
+        itemResponseTest = new ItemResponse(new Item[]{item}, null, null);
 
     }
 


### PR DESCRIPTION
This improvement adds a new field `time` to `ItemResponse` to return the server response time.

Background: To optimize our item processing, we are only interested in zone changes where the item remains in this zone for some x seconds. For example when I move an item from antenna 1 to antenna 2 there is a brief moment where none of the antennas pick up the signal, so the item gets transitioned to "absent". To filter out these events, I compare the current time with the last modification date and ignore events where this is less than x seconds. However, my clock seems to be a few seconds ahead of the ItemSense server clock. Therefore the calculation is inaccurate. Instead of hard coding a delay (which I would need to adjust every now and then), I now simply take the response time which is already part of the ItemSense HTTP response.

If you think this might be useful for others, too, please feel free to merge this into your repository.

Cheers
Patrick 