### PR TITLE
Updated JobResponse to handle json content for error correctly

### DIFF
--- a/src/main/java/com/impinj/itemsense/client/coordinator/job/JobResponseError.java
+++ b/src/main/java/com/impinj/itemsense/client/coordinator/job/JobResponseError.java
@@ -17,22 +17,9 @@ import java.time.ZonedDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class JobResponse {
-    private String id;
-    private String status;
-    private String [] readerNames;
+public class JobResponseError {
 
     @JsonDeserialize(using = ZonedDateTimeSerialization.class)
-    private ZonedDateTime creationTime;
-    @JsonDeserialize(using = ZonedDateTimeSerialization.class)
-    private ZonedDateTime lastActivityTime;
-    @JsonDeserialize(using = ZonedDateTimeSerialization.class)
-    private ZonedDateTime lastHeartbeatTime;
-
-    private String activeDuration;
-    private boolean errorOccurred;
-    private JobResponseError[] errors;
-    private Facility[] facilities;
-    private Job job;
-    //TODO:INSTANCE META DATA;
+    private ZonedDateTime time;
+    private String message;
 }

--- a/src/test/java/com.impinj.itemsense.client/coordinator/JobControllerTest.java
+++ b/src/test/java/com.impinj.itemsense.client/coordinator/JobControllerTest.java
@@ -65,6 +65,21 @@ public class JobControllerTest {
     }
 
     @Test
+    public void GetAllJobsWithErrors(){
+        String jobResponseStrings = "[{\"id\": \"5301035e-a5ea-47ad-92ef-596d9a2e790e\", \"status\": \"RUNNING\", \"readerNames\": [ \"Arlington_Office\" ], \"connectionType\": \"LLRP\", \"creationTime\": \"2016-06-15T21:14:19.488Z[Etc/UTC]\", \"lastActivityTime\": \"2016-06-16T01:39:33.423Z\", \"stateEntryTime\": \"2016-06-15T21:14:33.912Z\", \"activeDuration\": \"PT4H24M59.511S\", \"errorOccurred\": false, \"errors\": [], \"facilities\": [ { \"name\": \"Arlington\" } ], \"job\": { \"recipeName\": \"Arlington_Location\", \"durationSeconds\": 36000000, \"playbackLoggingEnabled\": false, \"presenceLoggingEnabled\": false, \"startDelay\": \"PT0S\", \"reportToDatabaseEnabled\": true, \"reportToMessageQueueEnabled\": null, \"reportToFileEnabled\": null, \"facility\": \"Arlington\" }, \"instanceMetadata\": { \"port\": 53869, \"instanceId\": \"194e1bb7-a7fc-4e41-968b-ce7bf1d6a1ee\", \"controlUrl\": \"http://localhost:53869/itemsense/readermanager\", \"connectionType\": \"LLRP\" }, \"lastHeartbeatTime\": \"2016-06-16T01:39:39.335Z[Etc/UTC]\", \"startAttempts\": 1 }, { \"id\": \"7f231ecb-3cd5-422f-b09c-670fbf8e4a1b\", \"status\": \"FAILED\", \"readerNames\": [ \"Arlington_Office\" ], \"connectionType\": \"LLRP\", \"creationTime\": \"2016-05-31T21:26:45.523Z[GMT]\", \"lastActivityTime\": \"2016-06-15T05:52:19.512Z[GMT]\", \"stateEntryTime\": \"2016-06-15T05:52:19.512Z[GMT]\", \"activeDuration\": \"PT0S\", \"errorOccurred\": true, \"errors\": [ { \"time\": \"2016-06-15T05:49:15.514Z[GMT]\", \"message\": \"Could not detect job progress, possibly dead or in a bad state : Heartbeat Timed Out\" }, { \"time\": \"2016-06-15T05:50:23.641Z[GMT]\", \"message\": \"Error publishing state to JobInstance : Initialization error: An error occurred while connecting to the reader (192.168.15.16): \" }, { \"time\": \"2016-06-15T05:51:20.618Z[GMT]\", \"message\": \"Error publishing state to JobInstance : Initialization error: An error occurred while connecting to the reader (192.168.15.16): \" }, { \"time\": \"2016-06-15T05:52:20.626Z[GMT]\", \"message\": \"Error publishing state to JobInstance : Initialization error: An error occurred while connecting to the reader (192.168.15.16): \" }, { \"time\": \"2016-06-15T05:52:20.797Z[GMT]\", \"message\": \"Job was unable to start within the maximum number of start attempts (4) : Failed job\" } ], \"facilities\": [ { \"name\": \"Arlington\" } ], \"job\": { \"recipeName\": \"Arlington_Location\", \"durationSeconds\": 36000000, \"playbackLoggingEnabled\": false, \"presenceLoggingEnabled\": false, \"startDelay\": \"PT0S\", \"reportToDatabaseEnabled\": true, \"reportToMessageQueueEnabled\": null, \"reportToFileEnabled\": null, \"facility\": \"Arlington\" }, \"instanceMetadata\": null, \"lastHeartbeatTime\": \"2016-06-15T05:52:18.584Z[GMT]\", \"startAttempts\": 4}]";
+        stubFor(get(urlEqualTo("/control/v1/jobs/show")).willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(jobResponseStrings)));
+
+        List<JobResponse> jobs = jobController.getJobs();
+        Assert.assertEquals(jobs.size(), 2);
+        Assert.assertThat(jobs, instanceOf(ArrayList.class));
+        Assert.assertThat(jobs.get(1), instanceOf(JobResponse.class));
+
+    }
+
+    @Test
     public void GetJob(){
 
         String jobResponseString = "{\"id\":\"05d2518b-b8e0-41b3-8112-481579d6b512\",\"status\":\"COMPLETE\",\"readerNames\":[\"Arlington_Office\"],\"creationTime\":\"2016-01-25T04:41:26.318Z[Etc/UTC]\",\"lastActivityTime\":\"2016-01-25T04:47:24.404Z\",\"activeDuration\":\"PT5M\",\"errorOccurred\":false,\"errors\":[],\"facilities\":[{\"name\":\"Arlington\"}],\"job\":{\"recipeName\":\"Arlington_Location\",\"durationSeconds\":300,\"playbackLoggingEnabled\":null,\"presenceLoggingEnabled\":null,\"startDelay\":\"PT0S\",\"reportToDatabaseEnabled\":null,\"reportToMessageQueueEnabled\":null,\"reportToFileEnabled\":null,\"facility\":\"Arlington\"},\"instanceMetadata\":null,\"lastHeartbeatTime\":\"2016-01-25T04:47:19.522Z[Etc/UTC]\"}";


### PR DESCRIPTION
I created a development branch and addressed the error object.  Added a test case to validate and updated the JobResponse to support failed jobs.  Any chance this (or any variation you would prefer) can make it's way all the way to maven central ASAP?  I need this to progress on my connector, and I'd prefer using maven central content.