### PR TITLE
Use a better Gson Java8-type-adapter library.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,9 +76,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fatboyindustrial.gson-javatime-serialisers</groupId>
-            <artifactId>gson-javatime-serialisers</artifactId>
-            <version>1.1.1</version>
+            <groupId>net.dongliu</groupId>
+            <artifactId>gson-java8-datatype</artifactId>
+            <version>1.0.2</version>
         </dependency>
 
         <dependency>

--- a/src/test/java/com.impinj.itemsense.client/TestUtils.java
+++ b/src/test/java/com.impinj.itemsense.client/TestUtils.java
@@ -3,7 +3,7 @@ package com.impinj.itemsense.client;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import com.fatboyindustrial.gsonjavatime.Converters;
+import net.dongliu.gson.GsonJava8TypeAdapterFactory;
 
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 
@@ -17,7 +17,9 @@ public abstract class TestUtils {
     public static final int MOCK_PORT = 8089;
     public static final URI MOCK_URI = URI.create(String.format("http://localhost:%d", MOCK_PORT));
 
-    private static final Gson GSON = Converters.registerAll(new GsonBuilder()).create();
+    private static final Gson GSON = new GsonBuilder()
+            .registerTypeAdapterFactory(new GsonJava8TypeAdapterFactory())
+            .create();
 
     public static Gson getGson() {
         return GSON;


### PR DESCRIPTION
In looking at testing for tag expiration, we realized that the gson type adapter library we'd been using previously doesn't support Durations.  I figured it'd be a good idea to swap it out here as well.