### PR TITLE
feature/PI-170-add-tagexpiry-duration-to-client-lib-recipe

### DIFF
--- a/src/main/java/com/impinj/itemsense/client/coordinator/recipe/Recipe.java
+++ b/src/main/java/com/impinj/itemsense/client/coordinator/recipe/Recipe.java
@@ -4,6 +4,7 @@ package com.impinj.itemsense.client.coordinator.recipe;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.time.Duration;
 import java.util.Map;
 
 import lombok.AllArgsConstructor;
@@ -28,5 +29,6 @@ public class Recipe {
     private Integer computeWindowSizeInCycles;
     private Integer computeWindowTimeInSeconds;
     private LocationAggregationModel locationAggregationModel;
+    private Duration tagExpiryDuration;
 }
 

--- a/src/test/java/com.impinj.itemsense.client/coordinator/RecipeControllerTest.java
+++ b/src/test/java/com.impinj.itemsense.client/coordinator/RecipeControllerTest.java
@@ -18,6 +18,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -55,7 +56,7 @@ public class RecipeControllerTest {
 
         coordinatorApiController = new CoordinatorApiController(client, TestUtils.MOCK_URI);
         recipeController = coordinatorApiController.getRecipeController();
-        gson = new Gson();
+        gson = TestUtils.getGson();
     }
 
     @After
@@ -69,6 +70,7 @@ public class RecipeControllerTest {
         testRecipe.setName("Test_Reader_Configuration");
         testRecipe.setZoneModel(ZoneModel.GEOGRAPHIC);
         testRecipe.setLocationAggregationModel(LocationAggregationModel.BY_CYCLES);
+        testRecipe.setTagExpiryDuration(Duration.ofSeconds(10));
 
         ArrayList<Recipe> testDefinitions = new ArrayList<>();
 
@@ -97,6 +99,7 @@ public class RecipeControllerTest {
         testRecipe.setName("Test_Reader_Configuration");
         testRecipe.setZoneModel(ZoneModel.GEOGRAPHIC);
         testRecipe.setLocationAggregationModel(LocationAggregationModel.BY_CYCLES);
+        testRecipe.setTagExpiryDuration(Duration.ofSeconds(10));
 
         stubFor(get(urlEqualTo("/configuration/v1/recipes/show/Test_Recipe")).willReturn(aResponse()
                 .withStatus(200)
@@ -124,13 +127,14 @@ public class RecipeControllerTest {
 
     @Test
     public void createRecipeTest() throws Exception {
-        String recipeStr = "{\"name\":\"New_Recipe\",\"type\":\"LLRP\",\"readerConfigurationName\":\"Test_Reader_Configuration\",\"presencePipelineEnabled\":false,\"locationReportingEnabled\":false,\"zoneModel\":\"GATEWAY\"}";
+        String recipeStr = "{\"name\":\"New_Recipe\",\"type\":\"LLRP\",\"readerConfigurationName\":\"Test_Reader_Configuration\",\"presencePipelineEnabled\":false,\"locationReportingEnabled\":false,\"zoneModel\":\"GATEWAY\",\"tagExpiryDuration\":\"PT10S\"}";
 
         Recipe testRecipe = new Recipe();
         testRecipe.setName("New_Recipe");
         testRecipe.setType(RecipeType.LLRP);
         testRecipe.setReaderConfigurationName("Test_Reader_Configuration");
         testRecipe.setZoneModel(ZoneModel.GATEWAY);
+        testRecipe.setTagExpiryDuration(Duration.ofSeconds(10));
 
         stubFor(post(urlEqualTo("/configuration/v1/recipes/create"))
             .willReturn(aResponse()

--- a/src/test/java/com.impinj.itemsense.client/coordinator/recipe/RecipeTest.java
+++ b/src/test/java/com.impinj.itemsense.client/coordinator/recipe/RecipeTest.java
@@ -2,6 +2,7 @@ package com.impinj.itemsense.client.coordinator.recipe;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.time.Duration;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -11,12 +12,14 @@ public class RecipeTest {
   @Test
   public void testRecipeDeserialization() throws Exception {
     ObjectMapper mapper = new ObjectMapper();
+    Duration tagExpiry = Duration.ofSeconds(10);
 
     Recipe recipe = new Recipe();
     recipe.setName("RECIPE");
     recipe.setType(RecipeType.LLRP);
     recipe.setZoneModel(ZoneModel.GATEWAY);
     recipe.setLocationAggregationModel(LocationAggregationModel.BY_TIME);
+    recipe.setTagExpiryDuration(tagExpiry);
 
     String string = mapper.writeValueAsString(recipe);
 
@@ -25,5 +28,6 @@ public class RecipeTest {
     Assert.assertEquals(RecipeType.LLRP, recipeDeserialized.getType());
     Assert.assertEquals(ZoneModel.GATEWAY, recipeDeserialized.getZoneModel());
     Assert.assertEquals(LocationAggregationModel.BY_TIME, recipeDeserialized.getLocationAggregationModel());
+    Assert.assertEquals(tagExpiry, recipeDeserialized.getTagExpiryDuration());
   }
 }


### PR DESCRIPTION
Adjustments made to Recipe class, and associated tests to accomodate tagExpiryDuration as described [here](https://jira.impinj.com/browse/PI-197)
